### PR TITLE
Add getMethodGroups shell api

### DIFF
--- a/src/rpc/shell/shell.js
+++ b/src/rpc/shell/shell.js
@@ -29,6 +29,11 @@ class Shell {
       .send('shell_getFilteredMethods');
   }
 
+  getMethodGroups () {
+    return this._provider
+      .send('shell_getMethodGroups');
+  }
+
   getMethodPermissions () {
     return this._provider
       .send('shell_getMethodPermissions');


### PR DESCRIPTION
Add a `shell_getMethodGroups` api to retrieve the methodGroups.

To be merged right after https://github.com/paritytech/parity/pull/7083