### PR TITLE
Fix es6-error dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@parity/wordlist": "1.1.x",
     "bignumber.js": "3.0.1",
     "blockies": "0.0.2",
-    "es6-error": "^4.0.0",
+    "es6-error": "4.0.2",
     "es6-promise": "^4.1.1",
     "eventemitter3": "^2.0.2",
     "isomorphic-fetch": "^2.2.1",


### PR DESCRIPTION
Use a fixed version (something was breaking from the new versions of `es6-error`).